### PR TITLE
Upgrading tornado to 4.5 for more flexible routing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 setuptools>=21.0
-tornado>=4.3
+tornado>=4.5
 marshmallow==2.13.1
 marshmallow_jsonapi==0.14.0

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     description='Tornado-based REST+JSONAPI framework',
     install_requires=[
         "setuptools>=21.0",
-        "tornado>=4.3",
+        "tornado>=4.5",
         "marshmallow>=2.13",
         "marshmallow_jsonapi>=0.14",
     ],


### PR DESCRIPTION
Tornado 4.3 has limited routing capabilities. We need to access the wildcard router
to set it up correctly