### PR TITLE
Adapted Api.route api to flask-rest-jsonapi

### DIFF
--- a/tornado_rest_jsonapi/tests/test_api.py
+++ b/tornado_rest_jsonapi/tests/test_api.py
@@ -12,7 +12,11 @@ class TestApi(unittest.TestCase):
         api = Api(app)
 
         # Register the classes.
-        api.route("/students/(.*)/", StudentDetails, "student")
+        api.route(
+            StudentDetails,
+            "student",
+            "/students/(.*)/",
+        )
 
         self.assertTrue(app.wildcard_router.add_rules.called)
 
@@ -20,19 +24,35 @@ class TestApi(unittest.TestCase):
         app = Mock()
         api = Api(app)
 
-        api.route("/students/(.*)/", StudentDetails, "student")
+        api.route(
+            StudentDetails,
+            "student",
+            "/students/(.*)/",
+        )
         with self.assertRaises(ValueError):
-            api.route("/students/(.*)/", StudentDetails, "student")
+            api.route(
+                StudentDetails,
+                "student",
+                "/students/(.*)/",
+            )
 
     def test_incorrect_class_registration(self):
         app = Mock()
         api = Api(app)
 
         with self.assertRaises(TypeError):
-            api.route("/students/(.*)/", "hello", "student")
+            api.route(
+                "hello",
+                "student",
+                "/students/(.*)/",
+            )
 
         with self.assertRaises(TypeError):
-            api.route("/students/(.*)/", int, "student")
+            api.route(
+                int,
+                "student",
+                "/students/(.*)/",
+            )
 
     def test_authenticator(self):
         app = Mock()

--- a/tornado_rest_jsonapi/tests/test_webapi.py
+++ b/tornado_rest_jsonapi/tests/test_webapi.py
@@ -21,10 +21,11 @@ class TestBase(AsyncHTTPTestCase, LogTrapTestCase):
         app = web.Application(debug=True)
         app.hub = mock.Mock()
         api = Api(app, base_urlpath='/api/v1/')
-        api.route("/students/", resource_handlers.StudentList, "students")
-        api.route("/students/(.*)/",
-                  resource_handlers.StudentDetails,
-                  "student")
+        api.route(resource_handlers.StudentList, "students", "/students/")
+        api.route(
+            resource_handlers.StudentDetails,
+            "student",
+            "/students/(.*)/")
         return app
 
     def _create_one_student(self, name, age):


### PR DESCRIPTION
Using the exact same signature as from flask-rest-jsonapi for the route() method